### PR TITLE
Add output file (JSON and TSV), live-results, timeout, cursor, and limit options

### DIFF
--- a/search.js
+++ b/search.js
@@ -46,7 +46,7 @@ const {argv} = require('yargs')
 .option('out', {
   type: 'string',
   normalize: true,
-  description: 'Path to an output file for results'
+  description: 'Path to output files for results (both JSON and TSV); file extension should be omitted'
 })
 .option('limit', {
   type: 'number',
@@ -256,14 +256,14 @@ async function run() {
 
   if (OUTFILE) {
     fs.writeFileSync(
-        OUTFILE,
+        `${OUTFILE}.json`,
         JSON.stringify(allResults, null, 2)
     );
     fs.writeFileSync(
         `${OUTFILE}.tsv`,
         tableAsTabSeparatedValues(allResults)
     );
-    process.stdout.write(`\nWrote results to ${OUTFILE}[.tsv]\n`);
+    process.stdout.write(`\nWrote results to ${OUTFILE}[.json|.tsv]\n`);
   }
 }
 

--- a/search.js
+++ b/search.js
@@ -215,7 +215,8 @@ async function run() {
   let cursor = CURSOR
   let allResults=[]
 
-  process.stdout.write(`\nGathering data (timeout=${TIMEOUT}) ..`);
+  let cursorInfo = cursor ? `, cursor=${cursor}` : ``;
+  process.stdout.write(`\nGathering data (timeout=${TIMEOUT}${cursorInfo})\n..`);
 
   // Bail gracefully for Ctrl+C
   process.on('SIGINT', function() {
@@ -232,9 +233,8 @@ async function run() {
     let result = await (doRequest(cursor))
     pageCount++;
     if (result) {
-      if (result.cursor) {
-        cursor = result.cursor
-      } else {
+      cursor = result.cursor
+      if (!cursor) {
         tryNextPage = false
       }
       if (LIVERESULTS && result.results.length > 0) {
@@ -264,7 +264,12 @@ async function run() {
         `${OUTFILE}.tsv`,
         tableAsTabSeparatedValues(allResults)
     );
-    process.stdout.write(`\nWrote results to ${OUTFILE}[.json|.tsv]\n`);
+    process.stdout.write(`\nWrote results to ${OUTFILE}{.json,.tsv}\n`);
+  }
+
+  if (cursor) {
+    // Print this at the end in case the terminal buffer is full of table results
+    process.stderr.write(`\nExited while processing cursor ${cursor}`)
   }
 }
 

--- a/search.js
+++ b/search.js
@@ -238,7 +238,7 @@ async function run() {
         tryNextPage = false
       }
       if (LIVERESULTS && result.results.length > 0) {
-        process.stdout.write(`\nResults for cursor ${cursor}`);
+        process.stdout.write(`\nResults for cursor ${cursor}\n`);
         drawTable(result.results)
       } else {
         process.stdout.write(".");

--- a/search.js
+++ b/search.js
@@ -220,6 +220,7 @@ async function run() {
   // Bail gracefully for Ctrl+C
   process.on('SIGINT', function() {
     tryNextPage = false;
+    process.stdout.write(`\nStopping after results of cursor ${cursor}`)
   });
 
   let pageCount = 0;

--- a/search.js
+++ b/search.js
@@ -217,6 +217,11 @@ async function run() {
 
   process.stdout.write(`\nGathering data (timeout=${TIMEOUT}) ..`);
 
+  // Bail gracefully for Ctrl+C
+  process.on('SIGINT', function() {
+    tryNextPage = false;
+  });
+
   let pageCount = 0;
   while(tryNextPage) {
     if (LIMIT && pageCount >= LIMIT) {
@@ -240,7 +245,7 @@ async function run() {
 
       allResults = allResults.concat(result.results)
     } else {
-      process.stderr.write(`\nSkipping failed request using cursor ${cursor}`)
+      process.stderr.write(`\nRetrying failed request using cursor ${cursor}`)
     }
   }
 

--- a/search.js
+++ b/search.js
@@ -212,8 +212,6 @@ async function run() {
   console.log(FILTERTEXT)
   console.log(`Hosts: ${allResults.length}`)
   drawTable(allResults)
-
-  // TOO dump CSV and JSON files
 }
 
 


### PR DESCRIPTION
I was hitting timeouts after a long time (20mins) of running the script, so I made some improvements :)

### Context
I came across this repo via https://discuss.newrelic.com/t/query-for-environment-snapshot-data/139913, which also mentioned https://github.com/newrelic-experimental/nr-find-log4j. I took a look at that one but I couldn't immediately figure out if/how it could query for what I need, which is the "Java version" of a bunch of services.

We're auditing our Java/JVM versions and wanted a tool to gather that info. We tried a number of NRQL queries but none seemed to expose that data. But I was able to get to it with this tool, which is great!

<img width="137" alt="image" src="https://user-images.githubusercontent.com/6391742/156219428-4602f175-d993-4858-9473-a2a39dbb3639.png">

<img width="277" alt="image" src="https://user-images.githubusercontent.com/6391742/156219394-1191188f-0986-45ed-9268-ea8583b33e09.png">

It was really helpful to debug using https://api.newrelic.com/graphiql, especially this:

```graphql
{
  actor {
    account(id: <redacted>) {
      agentEnvironment {
        environmentAttributes(filter: {startsWith: "Java version"}) {
          results {
            details {
              name
            }
            attributes {
              value
              attribute
            }
          }
          nextCursor
        }
      }
    }
  }
}
```

Which translates to this script command:

> ./search.js --account $ACCOUNTID --apikey $NEW_RELIC_API_KEY  --field settings --starts "Java" --out search_results.json
